### PR TITLE
Switched to boxt_rubocop gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_gem:
-  boxt_ruby_style_guide:
+  boxt_rubocop:
     - default.yml
     - rails.yml
     - rspec.yml

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
-  gem "boxt_ruby_style_guide", "9.4.2"
+  gem "boxt_rubocop", "0.0.1"
   gem "rake", "~> 13.0"
   gem "rspec", "~> 3.9"
   gem "rspec-rails", "~> 5.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,8 +73,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    boxt_ruby_style_guide (9.4.2)
-      rubocop (= 1.26.0)
+    boxt_rubocop (0.0.1)
+      rubocop (= 1.26.1)
       rubocop-faker (= 1.1.0)
       rubocop-rails (= 2.14.2)
       rubocop-rake (= 0.6.0)
@@ -180,7 +180,7 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
-    rubocop (1.26.0)
+    rubocop (1.26.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -227,7 +227,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  boxt_ruby_style_guide (= 9.4.2)
+  boxt_rubocop (= 0.0.1)
   filta!
   rake (~> 13.0)
   rspec (~> 3.9)


### PR DESCRIPTION
Switched to [boxt_rubocop](https://github.com/boxt/boxt_rubocop) gem which has the newly added `Layout/ClassStructure` cop.